### PR TITLE
Handle alternative dimension separators

### DIFF
--- a/App.py
+++ b/App.py
@@ -212,9 +212,37 @@ df_whirlpak = pd.DataFrame(data_whirlpak)
 # 4. Fonctions
 # -------------------------
 def parse_dimension(dim_str):
-    if pd.isna(dim_str): return np.nan, np.nan
-    parts = dim_str.replace(' ', '').split('x')
-    return float(parts[0]), float(parts[1])
+    """Convert a dimension string like ``'3 x 5'`` into two floats.
+
+    The original implementation assumed the separator between width and
+    height was always a lowercase ``'x'`` and that the numeric portions
+    were valid floats.  In practice the data can contain uppercase ``'X'``
+    or the multiplication symbol ``'×'`` as well as stray spaces.  When
+    such values were encountered ``float(parts[0])`` raised a ``ValueError``
+    and halted the comparison process.
+
+    To make the function robust we normalise the string, handle the common
+    variants of the separator and guard against badly formatted inputs by
+    returning ``(np.nan, np.nan)`` when parsing fails.
+    """
+    if pd.isna(dim_str):
+        return np.nan, np.nan
+
+    cleaned = (
+        str(dim_str)
+        .lower()               # handle upper-case "X"
+        .replace('×', 'x')     # handle multiplication sign
+        .replace(' ', '')
+    )
+
+    parts = cleaned.split('x')
+    if len(parts) != 2:
+        return np.nan, np.nan
+
+    try:
+        return float(parts[0]), float(parts[1])
+    except ValueError:
+        return np.nan, np.nan
 
 def calculate_area(dim_str):
     if pd.isna(dim_str): return np.nan

--- a/tests/test_parse_dimension.py
+++ b/tests/test_parse_dimension.py
@@ -1,0 +1,25 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path so that App.py can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from App import parse_dimension
+
+
+def test_parse_dimension_lowercase():
+    assert parse_dimension('3 x 5') == (3.0, 5.0)
+
+
+def test_parse_dimension_uppercase():
+    assert parse_dimension('3 X 5') == (3.0, 5.0)
+
+
+def test_parse_dimension_multiplication_sign():
+    assert parse_dimension('3×5') == (3.0, 5.0)
+
+
+def test_parse_dimension_invalid():
+    w, h = parse_dimension('invalid')
+    assert np.isnan(w) and np.isnan(h)


### PR DESCRIPTION
## Summary
- normalize dimension strings to handle uppercase X and multiplication signs
- add tests for parse_dimension edge cases

## Testing
- `pytest -q`
- `python App.py >/tmp/run.log && tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef78c2f08328a0481279eea522a0